### PR TITLE
SCAYT 2 - deSCAYTifyWebkitPaste patch

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -51,6 +51,10 @@
 					oParams.userDictionaryName = config.scayt_userDictionaryName || '';
 					oParams.sLang = config.scayt_sLang || 'en_US';
 
+					if(typeof editor.config.scayt_deSCAYTifyWebkitPaste !== 'boolean') {
+						editor.config.scayt_deSCAYTifyWebkitPaste = true;
+					}
+
 					// Introduce SCAYT onLoad callback. (#5632)
 					oParams.onLoad = function() {
 						// Draw down word marker to avoid being covered by background-color style.(#5466)
@@ -748,6 +752,25 @@
 
 			editor.on( 'showScaytState', showInitialState );
 			editor.on( 'instanceReady', showInitialState );
+
+			// get rid of SCAYT related spans and nbsp; which are inserted when copying and pasting between CKE instances with SCAYT enabled in webkit based browsers
+			editor.on( 'paste', function( evt ) {
+				if(editor.config.scayt_deSCAYTifyWebkitPaste)
+				{
+					if ( CKEDITOR.env.webkit )
+					{
+						var dataObj = evt.data,
+							data = dataObj.dataValue,
+							regex1 = /&nbsp;<span data-scaytid="[^"]*" data-scayt_word="[^"]*" style="background-color: rgb\(255, 255, 255\);">([^<]*)<\/span>&nbsp;/g,
+							regex2 = /&nbsp;<span data-scaytid="[^"]*" data-scayt_word="[^"]*" style="background-color: rgb\(255, 255, 255\);">([^<]*)<\/span>/g,
+							regex3 = /<span data-scaytid="[^"]*" data-scayt_word="[^"]*" style="background-color: rgb\(255, 255, 255\);">([^<]*)<\/span>&nbsp;/g,
+							regex4 = /<span data-scaytid="[^"]*" data-scayt_word="[^"]*" style="background-color: rgb\(255, 255, 255\);">([^<]*)<\/span>/g;
+
+						data = data.replace(regex1,' $1 ').replace(regex2,' $1').replace(regex3,'$1 ').replace(regex4,'$1');
+						dataObj.dataValue = data;
+					}
+				}
+			}, null, null, 15 );
 
 			// Start plugin
 			if ( editor.config.scayt_autoStartup ) {


### PR DESCRIPTION
## Pull Request

DeSCAYTifyWebkitPaste patch to get rid of SCAYT generated markup which is preserved when copying and pasting between CKE instances in a Webkit based browser.

This patch intended for SCAYT 2 (CKE 4.3.x) - I have branched from [c17c1af] and I believe this pull request should be merged into a separate branch in the main repo.

Separate pull request #67 has been committed for SCAYT 3 (CKE 4.4+)
## Underlying issue

Copying and pasting text containing spelling mistakes between CKE instances with SCAYT enabled in a Webkit based browser results in the SCAYT markup being pasted into the new instance.  Some of this markup is not removed, and as a result the formatting of the pasted text is severely corrupted, as webkit adds non breaking spaces around the invisible markup.

This issue can be demonstrated by copying the following text from one CKE instance, and pasting it back into the same or a different CKE instance:

This functionality can be disabled by setting the config parameter **scayt_deSCAYTifyWebkitPaste** to false (default true).

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eget libero urna. Praesent congue scelerisque felis ac dapibus. Etiam convallis tortor tellus, ac pretium nulla feugiat at. Etiam vel eleifend eros, ac iaculis quam. Aliquam tincidunt fermentum sapien, non pulvinar purus rhoncus quis. Duis a purus nec risus gravida molestie. In adipiscing nec urna nec luctus. Suspendisse ultricies urna ut facilisis lacinia. Phasellus congue ipsum quis urna sollicitudin, nec pellentesque tortor interdum. Mauris egestas in nisi ac varius. Nam condimentum ipsum id quam vestibulum, ac accumsan diam facilisis. Proin hendrerit orci venenatis magna auctor aliquam.
```

This patch is not a fix for the underlying issue, but rather a workaround which removes the vast majority of the source mangling that Webkit does when copying and pasting between contenteditable components. 
