### PR TITLE
SCAYT 3 - deSCAYTifyWebkitPaste patch

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -399,6 +399,25 @@ CKEDITOR.plugins.add('scayt', {
 			dialog.selectPage(scaytInstance.tabToOpen);
 		});
 
+		// get rid of SCAYT related spans and nbsp; which are inserted when copying and pasting between CKE instances with SCAYT enabled in webkit based browsers
+		editor.on( 'paste', function( evt ) {
+			if(editor.config.scayt_deSCAYTifyWebkitPaste)
+			{
+				if ( CKEDITOR.env.webkit )
+				{
+					var dataObj = evt.data,
+						data = dataObj.dataValue,
+						regex1 = /&nbsp;<span [^>]*data-scayt-word="[^"]*"[^>]*>([^<]*)<\/span>&nbsp;/g,
+						regex2 = /&nbsp;<span [^>]*data-scayt-word="[^"]*"[^>]*>([^<]*)<\/span>/g,
+						regex3 = /<span [^>]*data-scayt-word="[^"]*"[^>]*>([^<]*)<\/span>&nbsp;/g,
+						regex4 = /<span [^>]*data-scayt-word="[^"]*"[^>]*>([^<]*)<\/span>/g;
+
+					data = data.replace(regex1,' $1 ').replace(regex2,' $1').replace(regex3,'$1 ').replace(regex4,'$1');
+					dataObj.dataValue = data;
+				}
+			}
+		}, null, null, 15 );
+			
 		/*
 		After each 'paste' CKEditor call insertHtml and we have subscribed for 'insertHtml' event before
 		editor.on('paste', function(ev)
@@ -509,6 +528,10 @@ CKEDITOR.plugins.add('scayt', {
 
 		if(typeof CKEDITOR.config.scayt_handleUndoRedo !== 'boolean') {
 			CKEDITOR.config.scayt_handleUndoRedo = true;
+		}
+
+		if(typeof editor.config.scayt_deSCAYTifyWebkitPaste !== 'boolean') {
+			editor.config.scayt_deSCAYTifyWebkitPaste = true;
 		}
 	},
 	addRule: function(editor) {


### PR DESCRIPTION
## Pull Request

DeSCAYTifyWebkitPaste patch to get rid of SCAYT generated markup which is preserved when copying and pasting between CKE instances in a Webkit based browser.

This patch intended for SCAYT 3 (CKE 4.4+).

Separate pull request #66 has been committed for SCAYT 2 (CKE 4.3.x)
## Underlying issue

Copying and pasting text containing spelling mistakes between CKE instances with SCAYT enabled in a Webkit based browser results in the SCAYT markup being pasted into the new instance.  Some of this markup is not removed, and as a result the formatting of the pasted text is severely corrupted, as webkit adds non breaking spaces around the invisible markup.

This issue can be demonstrated by copying the following text from one CKE instance, and pasting it back into the same or a different CKE instance:

This functionality can be disabled by setting the config parameter **scayt_deSCAYTifyWebkitPaste** to false (default true).

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eget libero urna. Praesent congue scelerisque felis ac dapibus. Etiam convallis tortor tellus, ac pretium nulla feugiat at. Etiam vel eleifend eros, ac iaculis quam. Aliquam tincidunt fermentum sapien, non pulvinar purus rhoncus quis. Duis a purus nec risus gravida molestie. In adipiscing nec urna nec luctus. Suspendisse ultricies urna ut facilisis lacinia. Phasellus congue ipsum quis urna sollicitudin, nec pellentesque tortor interdum. Mauris egestas in nisi ac varius. Nam condimentum ipsum id quam vestibulum, ac accumsan diam facilisis. Proin hendrerit orci venenatis magna auctor aliquam.
```

This patch is not a fix for the underlying issue, but rather a workaround which removes the vast majority of the source mangling that Webkit does when copying and pasting between contenteditable components. 
