### PR TITLE
Removing "dir" attribute from body is wrong, and causes bugs

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -348,7 +348,7 @@ CKEDITOR.plugins.add('scayt', {
 				// remove custom data from body, to prevent waste properties showing in IE8
 				if(editor.document) { //GitHub #84 : make sure that document exists(e.g. when startup mode set to 'source')
 					editor.document.getBody().removeAttribute('_jquid');
-					editor.document.getBody().removeAttribute('dir');
+					// editor.document.getBody().removeAttribute('dir'); // <-- This caused bugs in fullPage edit mode, where the user can't save a custom dir attribute! This bug has been around since 2012
 				}
 			}
 		});


### PR DESCRIPTION
This caused bugs in fullPage edit mode, where the user can't save a custom dir attribute! 
This bug has been around since 2012