### PR TITLE
Plugin disable in IE < 8 and quirks but not in compatibility view I6, I7, I*

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -29,7 +29,7 @@ CKEDITOR.plugins.add('scayt', {
 			label : lang.text_title,
 			title : ( editor.plugins.wsc ? editor.lang.wsc.title : lang.text_title ),
 			// SCAYT doesn't work in IE Compatibility Mode and IE (8 & 9) Quirks Mode
-			modes : {wysiwyg: !(env.ie && ( env.version < 8 || env.quirks || env.ie6Compat || env.ie7Compat || env.ie8Compat || env.ie9Compat ) ) },
+			modes : {wysiwyg: !(env.ie && ( env.version < 8 || env.quirks || env.ie6Compat || env.ie7Compat || env.ie8Compat) ) },
 			toolbar: 'spellchecker,20',
 			refresh: function() {
 				var buttonState = editor.ui.instances.Scayt.getState();

--- a/plugin.js
+++ b/plugin.js
@@ -29,7 +29,7 @@ CKEDITOR.plugins.add('scayt', {
 			label : lang.text_title,
 			title : ( editor.plugins.wsc ? editor.lang.wsc.title : lang.text_title ),
 			// SCAYT doesn't work in IE Compatibility Mode and IE (8 & 9) Quirks Mode
-			modes : {wysiwyg: !(env.ie && ( env.version < 8 || env.quirks ) ) },
+			modes : {wysiwyg: !(env.ie && ( env.version < 8 || env.quirks || env.ie6Compat || env.ie7Compat || env.ie8Compat || env.ie9Compat ) ) },
 			toolbar: 'spellchecker,20',
 			refresh: function() {
 				var buttonState = editor.ui.instances.Scayt.getState();


### PR DESCRIPTION
In some users of my project, I found that it gets your IE with IE8 compatibility mode and leyaout plugin is broken. I saw that temporarily changed the plugin to be disabled in your document compatibility mode and not in the browser compatibility mode on the issue. I only had problems with IE8 mode, but the earlier amendment was intended to disable any IE <8 browser.