### PR TITLE
Update docs links

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1627,7 +1627,7 @@ CKEDITOR.on('scaytReady', function() {
  * Automatically enables SCAYT on editor startup. When set to `true`, this option turns on SCAYT automatically
  * after loading the editor.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_autoStartup = true;
  *
@@ -1639,7 +1639,7 @@ CKEDITOR.on('scaytReady', function() {
  * Enables Grammar As You Type (GRAYT) on SCAYT startup. When set to `true`, this option turns on GRAYT automatically
  * after SCAYT started.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.grayt_autoStartup = true;
  *
@@ -1652,7 +1652,7 @@ CKEDITOR.on('scaytReady', function() {
  * Enables SCAYT initialization when inline CKEditor is not focused. When set to `true`, SCAYT markup is
  * displayed in both inline editor states, focused and unfocused, so the SCAYT instance is not destroyed.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		 config.scayt_inlineModeImmediateMarkup = true;
  *
@@ -1672,7 +1672,7 @@ CKEDITOR.on('scaytReady', function() {
  * * Negative number &ndash; Five suggestions are shown in the main context menu. All other
  *     entries will be listed in the "More Suggestions" sub-menu.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  * Examples:
  *
@@ -1690,7 +1690,7 @@ CKEDITOR.on('scaytReady', function() {
  * Defines the minimum length of words that will be collected from the editor content for spell checking.
  * Possible value is any positive number.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  * Examples:
  *
@@ -1704,7 +1704,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * The parameter that receives a string with characters that will considered as separators.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// additional separator.
  *		config.scayt_customPunctuation  = '-';
@@ -1717,7 +1717,7 @@ CKEDITOR.on('scaytReady', function() {
  * Sets the customer ID for SCAYT. Used for hosted users only. Required for migration from free
  * to trial or paid versions.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// Load SCAYT using my customer ID.
  *		config.scayt_customerId  = 'your-encrypted-customer-id';
@@ -1730,7 +1730,7 @@ CKEDITOR.on('scaytReady', function() {
  * Enables and disables the "More Suggestions" sub-menu in the context menu.
  * Possible values are `'on'` and `'off'`.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// Disables the "More Suggestions" sub-menu.
  *		config.scayt_moreSuggestions = 'off';
@@ -1758,7 +1758,7 @@ CKEDITOR.on('scaytReady', function() {
  * Please note that availability of the "Options", "Languages" and "Dictionaries" items
  * also depends on the {@link CKEDITOR.config#scayt_uiTabs} option.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  * Example:
  *
@@ -1778,7 +1778,7 @@ CKEDITOR.on('scaytReady', function() {
  *
  * Customers with dedicated SCAYT license may also set `'pt_BR'` and `'pt_PT'`.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// Sets SCAYT to German.
  *		config.scayt_sLang = 'de_DE';
@@ -1793,7 +1793,7 @@ CKEDITOR.on('scaytReady', function() {
  * (disabled) value for each of the following entries, in this precise order,
  * separated by a comma (`','`): `'Options'`, `'Languages'`, and `'Dictionary'`.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// Hides the "Languages" tab.
  *		config.scayt_uiTabs = '1,0,1';
@@ -1805,7 +1805,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Sets the protocol for the WebSpellChecker service (`ssrv.cgi`) full path.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// Defines the protocol for the WebSpellChecker service (ssrv.cgi) path.
  *		config.scayt_serviceProtocol = 'https';
@@ -1817,7 +1817,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Sets the host for the WebSpellChecker service (`ssrv.cgi`) full path.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// Defines the host for the WebSpellChecker service (ssrv.cgi) path.
  *		config.scayt_serviceHost = 'my-host';
@@ -1829,7 +1829,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Sets the port for the WebSpellChecker service (`ssrv.cgi`) full path.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// Defines the port for the WebSpellChecker service (ssrv.cgi) path.
  *		config.scayt_servicePort = '2330';
@@ -1841,7 +1841,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Sets the path to the WebSpellChecker service (`ssrv.cgi`).
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// Defines the path to the WebSpellChecker service (ssrv.cgi).
  *		config.scayt_servicePath = 'my-path/ssrv.cgi';
@@ -1856,7 +1856,7 @@ CKEDITOR.on('scaytReady', function() {
  * Refer to [SCAYT documentation](@@BRANDING_MIGRATION_MANUAL_URL)
  * for more details.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_srcUrl = "http://my-host/spellcheck/lf/scayt/scayt.js";
  *
@@ -1871,7 +1871,7 @@ CKEDITOR.on('scaytReady', function() {
  * Refer to [SCAYT documentation](@@BRANDING_CUSTOM_DICT_MANUAL_URL)
  * for more details.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_customDictionaryIds = '3021,3456,3478';
  *
@@ -1886,7 +1886,7 @@ CKEDITOR.on('scaytReady', function() {
  * Refer to [SCAYT documentation](@@BRANDING_USER_DICT_MANUAL_URL)
  * for more details.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_userDictionaryName = 'MyDictionary';
  *
@@ -1903,7 +1903,7 @@ CKEDITOR.on('scaytReady', function() {
  * * `moresuggest` &ndash; The "More suggestions" word list.
  * * `control` &ndash; SCAYT commands, such as "Ignore" and "Add Word".
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  * Example:
  *
@@ -1918,7 +1918,7 @@ CKEDITOR.on('scaytReady', function() {
  * to fix SCAYT issues with incorrect `checkDirty` behavior. If set to `false`,
  * it provides better performance on big preloaded text.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_handleCheckDirty = 'false';
  *
@@ -1932,7 +1932,7 @@ CKEDITOR.on('scaytReady', function() {
  * to fix SCAYT issues with incorrect undo/redo behavior. If set to `false`,
  * it provides better performance on text undo/redo.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_handleUndoRedo = 'false';
  *
@@ -1945,7 +1945,7 @@ CKEDITOR.on('scaytReady', function() {
  * You may need to {@link CKEDITOR.config#scayt_disableOptionsStorage disable option storing} for this setting to be
  * effective because option storage has a higher priority.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_ignoreAllCapsWords = true;
  *
@@ -1959,7 +1959,7 @@ CKEDITOR.on('scaytReady', function() {
  * You may need to {@link CKEDITOR.config#scayt_disableOptionsStorage disable option storing} for this setting to be
  * effective because option storage has a higher priority.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_ignoreDomainNames = true;
  *
@@ -1973,7 +1973,7 @@ CKEDITOR.on('scaytReady', function() {
  * You may need to {@link CKEDITOR.config#scayt_disableOptionsStorage disable option storing} for this setting to be
  * effective because option storage has a higher priority.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_ignoreWordsWithMixedCases = true;
  *
@@ -1987,7 +1987,7 @@ CKEDITOR.on('scaytReady', function() {
  * You may need to {@link CKEDITOR.config#scayt_disableOptionsStorage disable option storing} for this setting to be
  * effective because option storage has a higher priority.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_ignoreWordsWithNumbers = true;
  *
@@ -2008,7 +2008,7 @@ CKEDITOR.on('scaytReady', function() {
  * * `'lang'` &ndash; Disables storing of the SCAYT spell check language.
  * * `'all'` &ndash; Disables storing of all SCAYT options.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  * Example:
  *
@@ -2027,7 +2027,7 @@ CKEDITOR.on('scaytReady', function() {
  * Specifies the names of tags that will be skipped while spell checking. This is a string containing tag names
  * separated by commas (`','`). Please note that the `'style'` tag would be added to specified tags list.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_elementsToIgnore = 'del,pre';
  *
@@ -2038,7 +2038,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Enables multi-language support in SCAYT. If set to `true`, turns on SCAYT multi-language support after loading the editor.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		config.scayt_multiLanguageMode = true;
  *
@@ -2051,7 +2051,7 @@ CKEDITOR.on('scaytReady', function() {
  * the {@link CKEDITOR.config#scayt_multiLanguageMode} option is set to `true` and the [Language](http://ckeditor.com/addon/language)
  * plugin is included and loaded in the editor. By default, all misspellings will still be underlined with the red waveline.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  * Example:
  *
@@ -2075,7 +2075,7 @@ CKEDITOR.on('scaytReady', function() {
  * The parameter disables cache for storing the most popular correct and misspelled words with their suggestions.
  * It is aimed at speeding up the proofreading process.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// disable cache.
  *		config.scayt_disableCache = true;
@@ -2089,7 +2089,7 @@ CKEDITOR.on('scaytReady', function() {
  * It is aimed at speeding up the proofreading process.
  * Note: It is recommended to change this value wisely as it might lead to exceeding the browser local storage.
  *
- * Read more in the [documentation](#!/guide/dev_spellcheck) and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
  *
  *		// set cache size.
  *		config.scayt_cacheSize = 2000;

--- a/plugin.js
+++ b/plugin.js
@@ -1627,7 +1627,7 @@ CKEDITOR.on('scaytReady', function() {
  * Automatically enables SCAYT on editor startup. When set to `true`, this option turns on SCAYT automatically
  * after loading the editor.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_autoStartup = true;
  *
@@ -1639,7 +1639,7 @@ CKEDITOR.on('scaytReady', function() {
  * Enables Grammar As You Type (GRAYT) on SCAYT startup. When set to `true`, this option turns on GRAYT automatically
  * after SCAYT started.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.grayt_autoStartup = true;
  *
@@ -1652,7 +1652,7 @@ CKEDITOR.on('scaytReady', function() {
  * Enables SCAYT initialization when inline CKEditor is not focused. When set to `true`, SCAYT markup is
  * displayed in both inline editor states, focused and unfocused, so the SCAYT instance is not destroyed.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		 config.scayt_inlineModeImmediateMarkup = true;
  *
@@ -1672,7 +1672,7 @@ CKEDITOR.on('scaytReady', function() {
  * * Negative number &ndash; Five suggestions are shown in the main context menu. All other
  *     entries will be listed in the "More Suggestions" sub-menu.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  * Examples:
  *
@@ -1690,7 +1690,7 @@ CKEDITOR.on('scaytReady', function() {
  * Defines the minimum length of words that will be collected from the editor content for spell checking.
  * Possible value is any positive number.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  * Examples:
  *
@@ -1704,7 +1704,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * The parameter that receives a string with characters that will considered as separators.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// additional separator.
  *		config.scayt_customPunctuation  = '-';
@@ -1717,7 +1717,7 @@ CKEDITOR.on('scaytReady', function() {
  * Sets the customer ID for SCAYT. Used for hosted users only. Required for migration from free
  * to trial or paid versions.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// Load SCAYT using my customer ID.
  *		config.scayt_customerId  = 'your-encrypted-customer-id';
@@ -1730,7 +1730,7 @@ CKEDITOR.on('scaytReady', function() {
  * Enables and disables the "More Suggestions" sub-menu in the context menu.
  * Possible values are `'on'` and `'off'`.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// Disables the "More Suggestions" sub-menu.
  *		config.scayt_moreSuggestions = 'off';
@@ -1758,7 +1758,7 @@ CKEDITOR.on('scaytReady', function() {
  * Please note that availability of the "Options", "Languages" and "Dictionaries" items
  * also depends on the {@link CKEDITOR.config#scayt_uiTabs} option.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  * Example:
  *
@@ -1778,7 +1778,7 @@ CKEDITOR.on('scaytReady', function() {
  *
  * Customers with dedicated SCAYT license may also set `'pt_BR'` and `'pt_PT'`.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// Sets SCAYT to German.
  *		config.scayt_sLang = 'de_DE';
@@ -1793,7 +1793,7 @@ CKEDITOR.on('scaytReady', function() {
  * (disabled) value for each of the following entries, in this precise order,
  * separated by a comma (`','`): `'Options'`, `'Languages'`, and `'Dictionary'`.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// Hides the "Languages" tab.
  *		config.scayt_uiTabs = '1,0,1';
@@ -1805,7 +1805,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Sets the protocol for the WebSpellChecker service (`ssrv.cgi`) full path.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// Defines the protocol for the WebSpellChecker service (ssrv.cgi) path.
  *		config.scayt_serviceProtocol = 'https';
@@ -1817,7 +1817,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Sets the host for the WebSpellChecker service (`ssrv.cgi`) full path.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// Defines the host for the WebSpellChecker service (ssrv.cgi) path.
  *		config.scayt_serviceHost = 'my-host';
@@ -1829,7 +1829,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Sets the port for the WebSpellChecker service (`ssrv.cgi`) full path.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// Defines the port for the WebSpellChecker service (ssrv.cgi) path.
  *		config.scayt_servicePort = '2330';
@@ -1841,7 +1841,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Sets the path to the WebSpellChecker service (`ssrv.cgi`).
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// Defines the path to the WebSpellChecker service (ssrv.cgi).
  *		config.scayt_servicePath = 'my-path/ssrv.cgi';
@@ -1856,7 +1856,7 @@ CKEDITOR.on('scaytReady', function() {
  * Refer to [SCAYT documentation](@@BRANDING_MIGRATION_MANUAL_URL)
  * for more details.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_srcUrl = "http://my-host/spellcheck/lf/scayt/scayt.js";
  *
@@ -1871,7 +1871,7 @@ CKEDITOR.on('scaytReady', function() {
  * Refer to [SCAYT documentation](@@BRANDING_CUSTOM_DICT_MANUAL_URL)
  * for more details.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_customDictionaryIds = '3021,3456,3478';
  *
@@ -1886,7 +1886,7 @@ CKEDITOR.on('scaytReady', function() {
  * Refer to [SCAYT documentation](@@BRANDING_USER_DICT_MANUAL_URL)
  * for more details.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_userDictionaryName = 'MyDictionary';
  *
@@ -1903,7 +1903,7 @@ CKEDITOR.on('scaytReady', function() {
  * * `moresuggest` &ndash; The "More suggestions" word list.
  * * `control` &ndash; SCAYT commands, such as "Ignore" and "Add Word".
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  * Example:
  *
@@ -1918,7 +1918,7 @@ CKEDITOR.on('scaytReady', function() {
  * to fix SCAYT issues with incorrect `checkDirty` behavior. If set to `false`,
  * it provides better performance on big preloaded text.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_handleCheckDirty = 'false';
  *
@@ -1932,7 +1932,7 @@ CKEDITOR.on('scaytReady', function() {
  * to fix SCAYT issues with incorrect undo/redo behavior. If set to `false`,
  * it provides better performance on text undo/redo.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_handleUndoRedo = 'false';
  *
@@ -1945,7 +1945,7 @@ CKEDITOR.on('scaytReady', function() {
  * You may need to {@link CKEDITOR.config#scayt_disableOptionsStorage disable option storing} for this setting to be
  * effective because option storage has a higher priority.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_ignoreAllCapsWords = true;
  *
@@ -1959,7 +1959,7 @@ CKEDITOR.on('scaytReady', function() {
  * You may need to {@link CKEDITOR.config#scayt_disableOptionsStorage disable option storing} for this setting to be
  * effective because option storage has a higher priority.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_ignoreDomainNames = true;
  *
@@ -1973,7 +1973,7 @@ CKEDITOR.on('scaytReady', function() {
  * You may need to {@link CKEDITOR.config#scayt_disableOptionsStorage disable option storing} for this setting to be
  * effective because option storage has a higher priority.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_ignoreWordsWithMixedCases = true;
  *
@@ -1987,7 +1987,7 @@ CKEDITOR.on('scaytReady', function() {
  * You may need to {@link CKEDITOR.config#scayt_disableOptionsStorage disable option storing} for this setting to be
  * effective because option storage has a higher priority.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_ignoreWordsWithNumbers = true;
  *
@@ -2008,7 +2008,7 @@ CKEDITOR.on('scaytReady', function() {
  * * `'lang'` &ndash; Disables storing of the SCAYT spell check language.
  * * `'all'` &ndash; Disables storing of all SCAYT options.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  * Example:
  *
@@ -2027,7 +2027,7 @@ CKEDITOR.on('scaytReady', function() {
  * Specifies the names of tags that will be skipped while spell checking. This is a string containing tag names
  * separated by commas (`','`). Please note that the `'style'` tag would be added to specified tags list.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_elementsToIgnore = 'del,pre';
  *
@@ -2038,7 +2038,7 @@ CKEDITOR.on('scaytReady', function() {
 /**
  * Enables multi-language support in SCAYT. If set to `true`, turns on SCAYT multi-language support after loading the editor.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		config.scayt_multiLanguageMode = true;
  *
@@ -2051,7 +2051,7 @@ CKEDITOR.on('scaytReady', function() {
  * the {@link CKEDITOR.config#scayt_multiLanguageMode} option is set to `true` and the [Language](http://ckeditor.com/addon/language)
  * plugin is included and loaded in the editor. By default, all misspellings will still be underlined with the red waveline.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  * Example:
  *
@@ -2075,7 +2075,7 @@ CKEDITOR.on('scaytReady', function() {
  * The parameter disables cache for storing the most popular correct and misspelled words with their suggestions.
  * It is aimed at speeding up the proofreading process.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// disable cache.
  *		config.scayt_disableCache = true;
@@ -2089,7 +2089,7 @@ CKEDITOR.on('scaytReady', function() {
  * It is aimed at speeding up the proofreading process.
  * Note: It is recommended to change this value wisely as it might lead to exceeding the browser local storage.
  *
- * Read more in the {@glink features/spellcheck documentation} and see the [SDK sample](http://sdk.ckeditor.com/samples/spellchecker.html).
+ * Read more in the {@glink features/spellcheck documentation} and see the {@glink examples/spellchecker SDK sample}.
  *
  *		// set cache size.
  *		config.scayt_cacheSize = 2000;


### PR DESCRIPTION
With recent changes in https://github.com/ckeditor/ckeditor-docs some documentation links needs to be updated, more info here: https://github.com/ckeditor/ckeditor-dev/issues/3178 

To check if everything works as expected:
- Clone https://github.com/ckeditor/ckeditor-docs
- Follow the building instructions
- Go to `ckeditor-docs/repos/ckeditor-presets/plugins/scayt`
- Change branch to one from this PR
- Go back to `ckeditor-docs` and run build command.

Closes https://github.com/ckeditor/ckeditor-dev/issues/3178 