### PR TITLE
Fix scope for overriden `autocomplete.getModel()` function

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -31,7 +31,8 @@ CKEDITOR.plugins.add('scayt', {
 
 			CKEDITOR.plugins.autocomplete.prototype.getModel = function(arg1) {
 				var editor = this.editor,
-					model = originalFn(arg1);
+					geModelFn = originalFn.bind(this),
+					model = geModelFn(arg1);
 
 				model.on('change-isActive', function(evt) {
 					evt.data ? editor.fire('autocompletePanelShow') : editor.fire('autocompletePanelHide');


### PR DESCRIPTION
We have discovered that the proposed workaround calls original function with invalid scope meaning that [some properties which are accessed based on scope function](https://github.com/ckeditor/ckeditor4/blob/ffd8a623e0e74cce75eed8876af920487f3b721c/plugins/autocomplete/plugin.js#L396) are incorrect.