### PR TITLE
Updated cloud protocol service to always use https

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -702,10 +702,7 @@ CKEDITOR.plugins.add('scayt', {
 		}
 
 		if(typeof editor.config.scayt_srcUrl !== 'string') {
-			var protocol = document.location.protocol;
-			protocol = protocol.search(/https?:/) != -1 ? protocol : 'http:';
-
-			editor.config.scayt_srcUrl = protocol + '//svc.webspellchecker.net/spellcheck31/wscbundle/wscbundle.js';
+			editor.config.scayt_srcUrl = 'https://svc.webspellchecker.net/spellcheck31/wscbundle/wscbundle.js';
 		}
 
 		if(typeof CKEDITOR.config.scayt_handleCheckDirty !== 'boolean') {


### PR DESCRIPTION
According to our discussion on Slack, Scayt should always use `HTTPS` protocol when connecting to the cloud service. Currently, if someone is using `http` domain, Scayt will stop working as the request will also go through `http`.